### PR TITLE
The metadata attribtue blew up for me when running build on ubuntu 14.04...

### DIFF
--- a/logstash-output-batch_http.gemspec
+++ b/logstash-output-batch_http.gemspec
@@ -15,7 +15,8 @@ Gem::Specification.new do |s|
   s.test_files = s.files.grep(%r{^(test|spec|features)/})
 
   # Special flag to let us know this is actually a logstash plugin
-  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
+  # This metadata attribute blew up for me on Ubuntu 14.04 with the latest rubgems installed
+  #s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 2.0.0"


### PR DESCRIPTION
... with the latest rubygems
