### PR TITLE
Fix batching

### DIFF
--- a/lib/logstash/outputs/jut.rb
+++ b/lib/logstash/outputs/jut.rb
@@ -54,6 +54,9 @@ class LogStash::Outputs::Jut < LogStash::Outputs::Base
 
     evt = event.to_hash
     @batcher.receive(evt)
+
+  rescue Exception => e
+    @logger.warn("Unhandled exception", :exception => e, :stacktrace => e.backtrace)
   end
 
   public

--- a/logstash-output-jut.gemspec
+++ b/logstash-output-jut.gemspec
@@ -1,8 +1,8 @@
 Gem::Specification.new do |s|
   s.name = 'logstash-output-jut'
-  s.version = "0.1.1"
+  s.version = "0.2"
   s.licenses = ["Apache License (2.0)"]
-  s.summary = "Batches HTTP POST requests"
+  s.summary = "sends records to a Jut data engine"
   s.description = "logstash output plugin that sends records to a Jut data engine"
   s.authors = ["Jut, Inc."]
   s.email = "josa@jut.io"
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   # Special flag to let us know this is actually a logstash plugin
   # This metadata attribute blew up for me on Ubuntu 14.04 with the latest rubgems installed
-  #s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
+  s.metadata = { "logstash_plugin" => "true", "logstash_group" => "output" }
 
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 2.0.0"

--- a/logstash-output-jut.gemspec
+++ b/logstash-output-jut.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
   # Gem dependencies
   s.add_runtime_dependency "logstash-core", ">= 1.4.0", "< 2.0.0"
   s.add_runtime_dependency "logstash-codec-plain"
+  s.add_runtime_dependency "work_queue"
+
   s.add_development_dependency "logstash-devutils"
-  s.add_runtime_dependency 'ftw', ['~> 0.0.40']
 end


### PR DESCRIPTION
Re-do the algorithm used by HTTPBatcher.  Previously we had worker threads that woke up periodically and sent (some of) what was queued up while they were sleeping.  Now, we immediately do a POST when we have enough records to fill up a single POST and only do a timer-based send if we don't receive anything for some period of time (ie, Nagle's algorithm)
